### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,9 @@ Using COSTouchVisualizer is possible with Swift.  Inside your AppDelegate, redef
 **With Storyboards**
 ```swift
 class AppDelegate: UIResponder {
-  var visWindow: COSTouchVisualizerWindow?
-  var window: COSTouchVisualizerWindow? {
-    if visWindow == nil { visWindow = COSTouchVisualizerWindow(frame: UIScreen.mainScreen().bounds) }
-    return visWindow
-  }
+  lazy var window: COSTouchVisualizerWindow? = {
+    COSTouchVisualizerWindow(frame: UIScreen.mainScreen().bounds)
+  }()
 ...
 }
 ```


### PR DESCRIPTION
Simplify Swift usage example by using a lazy property. That makes the `visWindow` property obsolete.

While we're on it, is the Swift usage example _without Storyboards_ intentionally left blank?
