### PR TITLE
Fixed status bar style hidden by overlay window

### DIFF
--- a/Classes/COSTouchVisualizerWindow.m
+++ b/Classes/COSTouchVisualizerWindow.m
@@ -15,11 +15,15 @@
 
 @end
 
+@interface COSTouchOverlayWindowViewController : UIViewController
+@end
+
 #pragma mark -
 
 @interface COSTouchVisualizerWindow ()
 
 @property (nonatomic, strong) UIWindow *overlayWindow;
+@property (nonatomic, strong) UIViewController *overlayWindowViewController;
 @property (nonatomic, assign) BOOL fingerTipRemovalScheduled;
 @property (nonatomic, strong) NSTimer *timer;
 
@@ -45,6 +49,7 @@
 @synthesize rippleFadeDuration = _rippleFadeDuration;
 
 @synthesize overlayWindow = _overlayWindow;
+@synthesize overlayWindowViewController = _overlayWindowViewController;
 @synthesize active = _active;
 @synthesize fingerTipRemovalScheduled = _fingerTipRemovalScheduled;
 
@@ -250,6 +255,10 @@
         _overlayWindow.windowLevel = UIWindowLevelStatusBar;
         _overlayWindow.backgroundColor = [UIColor clearColor];
         _overlayWindow.hidden = NO;
+        
+        _overlayWindowViewController = [[COSTouchOverlayWindowViewController alloc] init];
+        [_overlayWindow setRootViewController:_overlayWindowViewController];
+        [_overlayWindowViewController setView:_overlayWindow];
     }
 
     return _overlayWindow;
@@ -403,5 +412,12 @@
 #pragma mark -
 
 @implementation COSTouchSpotView
+@end
+
+@implementation COSTouchOverlayWindowViewController 
+
+- (UIStatusBarStyle)preferredStatusBarStyle {
+    return [UIApplication sharedApplication].keyWindow.rootViewController.preferredStatusBarStyle;
+}
 
 @end


### PR DESCRIPTION
Introduced a view controller for the overlay window to preserve the preferred status bar style for the main window. This prevents losing the status bar style when the new window is created and its own status bar hides the main window.

One way to reproduce this issue is by adding a navigation bar and changing its style to be dark (with white fonts) and then tap anywhere.

Originally the status bar was going to change its appearance to the default style.
Currently is going to be set based on the keyWIndow rootViewController preferredStatusBarStyle property.
