### PR TITLE
Made iPad-compat

### DIFF
--- a/Example/TouchVisualizer.xcodeproj/project.pbxproj
+++ b/Example/TouchVisualizer.xcodeproj/project.pbxproj
@@ -433,6 +433,7 @@
 				GCC_PREFIX_HEADER = "TouchVisualizer/TouchVisualizer-Prefix.pch";
 				INFOPLIST_FILE = "TouchVisualizer/TouchVisualizer-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -447,6 +448,7 @@
 				GCC_PREFIX_HEADER = "TouchVisualizer/TouchVisualizer-Prefix.pch";
 				INFOPLIST_FILE = "TouchVisualizer/TouchVisualizer-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TARGETED_DEVICE_FAMILY = "1,2";
 				WRAPPER_EXTENSION = app;
 			};
 			name = Release;


### PR DESCRIPTION
Changed the Example project's build settings to target both iPhone and iPad devices.
» iPhone-only makes me cry a little inside.
» With Apple producing iPhones now with a variety of screen size and resolutions, there's little argument remaining not to allow layouting-up to iPad-size too.  A case can still be made for iPad-optimized UIs, of course, but layout-expanded looks a million times better than the built-in iPad 2X scaling for iPhone-only apps.
