### PR TITLE
Including UIKit back to fix compilation errors

### DIFF
--- a/Classes/COSTouchVisualizerWindow.h
+++ b/Classes/COSTouchVisualizerWindow.h
@@ -5,6 +5,7 @@
 //  Created by Joe Blau on 3/22/14.
 //  Copyright (c) 2014 conopsys. All rights reserved.
 //
+#include <UIKit/UIKit.h>
 
 @protocol COSTouchVisualizerWindowDelegate;
 


### PR DESCRIPTION
This addresses a compilation error for those using COSTouchVisualizer on a swift project.

Description of the problem:
If the pod is included on an objective C project, UIKit is included on the headers without issues. But when the consumer project is written on swift UIKit is not available on the global header causing COSTouchVisualizerWindow to not build as it can't find Foundation or UIKit.
