### PR TITLE
Prevents build-up of NSTimers..

### DIFF
--- a/Classes/COSTouchVisualizerWindow.m
+++ b/Classes/COSTouchVisualizerWindow.m
@@ -219,6 +219,10 @@
                         [self.overlayWindow addSubview:touchView];
 
                         if (self.stationaryMorphEnabled) {
+                            if (self.timer) {
+                                [self.timer invalidate];
+                            }
+
                             self.timer = [NSTimer scheduledTimerWithTimeInterval:0.6
                                                                           target:self
                                                                         selector:@selector(performMorph:)


### PR DESCRIPTION
Thus preventing CPU usage buildup.

This should help with https://github.com/conopsys/COSTouchVisualizer/issues/24